### PR TITLE
Discord domain migration

### DIFF
--- a/docs/Troubleshooting-doc5.md
+++ b/docs/Troubleshooting-doc5.md
@@ -9,7 +9,7 @@ title: Basic Troubleshooting
 You must have a role with the “Administrator” or the “Manage Server” permission to be able to add Rythm to a Discord Server. 
 *If you are able to change the name of the server, you have one of these permissions.*
 
-If you have the correct permission and still can’t see your server in the list, make sure you’re logged into the correct Discord account in your web browser which you can check by going [here](https://discordapp.com/channels/@me).
+If you have the correct permission and still can’t see your server in the list, make sure you’re logged into the correct Discord account in your web browser which you can check by going [here](https://discord.com/channels/@me).
 
 Note: If that still doesn't work, we suggest trying **Incognito Mode** in your web browser or a different browser to invite Rythm to your server. An incognito guide/table will be below:
 

--- a/docs/mobile troubleshooting-doc7.md
+++ b/docs/mobile troubleshooting-doc7.md
@@ -3,7 +3,7 @@ id: mobile_troubleshooting
 title: Mobile Troubleshooting
 ---
 
-If you are on mobile and you find that you cannot add Rythm due to the fact that the link to add Rythm produces a gray screen, then please try first heading to https://discordapp.com/login, logging in and then using the invite link again.
+If you are on mobile and you find that you cannot add Rythm due to the fact that the link to add Rythm produces a gray screen, then please try first heading to https://discord.com/login, logging in and then using the invite link again.
 If that does not work, we recommend using a desktop device.
 
 In short: You may want to try refreshing the website to add Rythm or use a desktop device.


### PR DESCRIPTION
Discord migrated the primary domain.

This PR updates a few references to reflect that